### PR TITLE
【bug修复】修复工程无法打包，插件无法运行的问题

### DIFF
--- a/lubanops-apm-javaagent-packaging/src/main/resources/dev/apm.config
+++ b/lubanops-apm-javaagent-packaging/src/main/resources/dev/apm.config
@@ -11,7 +11,3 @@ business=apm2
 sub.business=subTestDemo
 env.secret=
 interceptor.chains=com.huawei.hwclouds.lubanops.interceptor.DInterceptor,com.huawei.hwclouds.lubanops.interceptor.BInterceptor,com.huawei.hwclouds.lubanops.interceptor.AInterceptor,com.huawei.hwclouds.lubanops.interceptor.CInterceptor
-route.database.plugin.on=true
-route.database.plugin.type=1
-route.database.plugin.db=datasource0
-route.database.plugin.effect=true

--- a/lubanops-apm-javaagent-packaging/src/main/resources/fuxi/apm.config
+++ b/lubanops-apm-javaagent-packaging/src/main/resources/fuxi/apm.config
@@ -13,7 +13,3 @@ event.thread.count=3
 #sub.business={{sub_business}}
 #env.secret=
 interceptor.chains=com.huawei.hwclouds.lubanops.interceptor.DInterceptor,com.huawei.hwclouds.lubanops.interceptor.BInterceptor,com.huawei.hwclouds.lubanops.interceptor.AInterceptor,com.huawei.hwclouds.lubanops.interceptor.CInterceptor
-route.database.plugin.on=true
-route.database.plugin.type=1
-route.database.plugin.db=datasource0
-route.database.plugin.effect=true

--- a/lubanops-apm-javaagent-packaging/src/main/resources/jdk6/apm.config
+++ b/lubanops-apm-javaagent-packaging/src/main/resources/jdk6/apm.config
@@ -10,7 +10,3 @@ business=apm2
 sub.business=subTestDemo
 env.secret=
 interceptor.chains=com.huawei.hwclouds.lubanops.interceptor.DInterceptor,com.huawei.hwclouds.lubanops.interceptor.BInterceptor,com.huawei.hwclouds.lubanops.interceptor.AInterceptor,com.huawei.hwclouds.lubanops.interceptor.CInterceptor
-route.database.plugin.on=true
-route.database.plugin.type=1
-route.database.plugin.db=datasource0
-route.database.plugin.effect=true

--- a/lubanops-apm-javaagent-premain/pom.xml
+++ b/lubanops-apm-javaagent-premain/pom.xml
@@ -44,7 +44,7 @@
                                 <fileset>
                                     <directory>${package.dir}</directory>
                                     <includes>
-                                        <include>${javaagent.package.name}.jar</include>
+                                        <include>*${javaagent.package.name}*.jar</include>
                                     </includes>
                                 </fileset>
                             </filesets>
@@ -76,7 +76,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
-                    <finalName>${javaagent.package.name}</finalName>
+                    <outputFile>${package.dir}/${javaagent.package.name}.jar</outputFile>
                 </configuration>
             </plugin>
         </plugins>

--- a/lubanops-apm-javaagent-premain/src/main/java/com/huawei/apm/config/CommonLoadConfigStrategy.java
+++ b/lubanops-apm-javaagent-premain/src/main/java/com/huawei/apm/config/CommonLoadConfigStrategy.java
@@ -294,6 +294,8 @@ public class CommonLoadConfigStrategy implements LoadConfigStrategy<Properties> 
             result = Boolean.parseBoolean(configStr);
         } else if (type == Boolean.class) {
             result = Boolean.valueOf(configStr);
+        } else if (type.isEnum()) {
+            result = Enum.valueOf((Class) type, configStr);
         } else if (type == String.class || type == Object.class) {
             result = configStr;
         } else {

--- a/lubanops-apm-javaagent-premain/src/main/java/com/huawei/apm/config/CommonLoadConfigStrategy.java
+++ b/lubanops-apm-javaagent-premain/src/main/java/com/huawei/apm/config/CommonLoadConfigStrategy.java
@@ -156,7 +156,7 @@ public class CommonLoadConfigStrategy implements LoadConfigStrategy<Properties> 
      *     1.{@link #fixConfig}方法，修正形如"${}"的配置
      *     2.{@link #toBaseType}等方法，将配置信息字符串进行类型转换
      * </pre>
-     * 支持int、short、long、float、double、String和Object类型，以及他们构成的数组、List和Map
+     * 支持int、short、long、float、double、枚举、String和Object类型，以及他们构成的数组、List和Map
      *
      * @param config 配置主要承载对象{@link Properties}
      * @param key    配置键
@@ -258,7 +258,7 @@ public class CommonLoadConfigStrategy implements LoadConfigStrategy<Properties> 
     }
 
     /**
-     * 将配置信息字符串进行类型转换，支持int、short、long、float、double、String和Object类型，转换失败时返回null
+     * 将配置信息字符串进行类型转换，支持int、short、long、float、double、枚举、String和Object类型，转换失败时返回null
      *
      * @param configStr 配置信息字符串
      * @param type      配置对象属性类型

--- a/lubanops-apm-javaagent-premain/src/main/java/com/lubanops/apm/premain/AgentPremain.java
+++ b/lubanops-apm-javaagent-premain/src/main/java/com/lubanops/apm/premain/AgentPremain.java
@@ -63,19 +63,19 @@ public class AgentPremain {
                 ClassLoader parent = Thread.currentThread().getContextClassLoader();
                 // 配置初始化
                 ConfigLoader.initialize(agentArgs, ClassLoaderManager.getTargetClassLoader(parent));
-                LopsUrlClassLoader classLoader = (LopsUrlClassLoader) AccessController.doPrivileged(
-                    new PrivilegedAction() {
-                        @Override
-                        public Object run() {
-                            return new LopsUrlClassLoader(urls.toArray(new URL[urls.size()]), null);
-                        }
-                    });
-
-                Thread.currentThread().setContextClassLoader(classLoader);
-                Class<?> mainClass = classLoader.loadClass("com.lubanops.apm.core.BootStrapImpl");
-                Method startMethod = mainClass.getDeclaredMethod("main", Instrumentation.class, Map.class);
-                startMethod.invoke(null, instrumentation, argsMap);
-                Thread.currentThread().setContextClassLoader(parent);
+//                LopsUrlClassLoader classLoader = (LopsUrlClassLoader) AccessController.doPrivileged(
+//                    new PrivilegedAction() {
+//                        @Override
+//                        public Object run() {
+//                            return new LopsUrlClassLoader(urls.toArray(new URL[urls.size()]), null);
+//                        }
+//                    });
+//
+//                Thread.currentThread().setContextClassLoader(classLoader);
+//                Class<?> mainClass = classLoader.loadClass("com.lubanops.apm.core.BootStrapImpl");
+//                Method startMethod = mainClass.getDeclaredMethod("main", Instrumentation.class, Map.class);
+//                startMethod.invoke(null, instrumentation, argsMap);
+//                Thread.currentThread().setContextClassLoader(parent);
                 // 针对NoneNamedListener初始化增强
                 NoneNamedListenerBuilder.initialize(instrumentation);
                 // 初始化byte buddy
@@ -86,8 +86,8 @@ public class AgentPremain {
                 logger.log(Level.SEVERE, "[APM PREMAIN]The JavaAgent is loaded repeatedly.");
             }
             AgentPremain.agentStatus = AgentStatus.STARTED;
-        } catch (InvocationTargetException e) {
-            logger.log(Level.SEVERE, "[APM PREMAIN]Loading javaagent failed", e.getTargetException());
+//        } catch (InvocationTargetException e) {
+//            logger.log(Level.SEVERE, "[APM PREMAIN]Loading javaagent failed", e.getTargetException());
         } catch (Exception e) {
             logger.log(Level.SEVERE, "[APM PREMAIN]Loading javaagent failed", e);
         }

--- a/lubanops-apm-javaagent-premain/src/main/java/com/lubanops/apm/premain/AgentPremain.java
+++ b/lubanops-apm-javaagent-premain/src/main/java/com/lubanops/apm/premain/AgentPremain.java
@@ -63,19 +63,6 @@ public class AgentPremain {
                 ClassLoader parent = Thread.currentThread().getContextClassLoader();
                 // 配置初始化
                 ConfigLoader.initialize(agentArgs, ClassLoaderManager.getTargetClassLoader(parent));
-//                LopsUrlClassLoader classLoader = (LopsUrlClassLoader) AccessController.doPrivileged(
-//                    new PrivilegedAction() {
-//                        @Override
-//                        public Object run() {
-//                            return new LopsUrlClassLoader(urls.toArray(new URL[urls.size()]), null);
-//                        }
-//                    });
-//
-//                Thread.currentThread().setContextClassLoader(classLoader);
-//                Class<?> mainClass = classLoader.loadClass("com.lubanops.apm.core.BootStrapImpl");
-//                Method startMethod = mainClass.getDeclaredMethod("main", Instrumentation.class, Map.class);
-//                startMethod.invoke(null, instrumentation, argsMap);
-//                Thread.currentThread().setContextClassLoader(parent);
                 // 针对NoneNamedListener初始化增强
                 NoneNamedListenerBuilder.initialize(instrumentation);
                 // 初始化byte buddy
@@ -86,8 +73,6 @@ public class AgentPremain {
                 logger.log(Level.SEVERE, "[APM PREMAIN]The JavaAgent is loaded repeatedly.");
             }
             AgentPremain.agentStatus = AgentStatus.STARTED;
-//        } catch (InvocationTargetException e) {
-//            logger.log(Level.SEVERE, "[APM PREMAIN]Loading javaagent failed", e.getTargetException());
         } catch (Exception e) {
             logger.log(Level.SEVERE, "[APM PREMAIN]Loading javaagent failed", e);
         }

--- a/plugins/flowcontrol-plugin/pom.xml
+++ b/plugins/flowcontrol-plugin/pom.xml
@@ -13,6 +13,7 @@
 
     <properties>
         <sentinel.version>1.8.0</sentinel.version>
+        <package.clean.skip.flag>false</package.clean.skip.flag>
         <shade.distinct.prefix>com.lubanops.apm.dependencies.flowcontrol</shade.distinct.prefix>
     </properties>
     <dependencies>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -17,7 +17,6 @@
     </properties>
     <modules>
         <module>flowcontrol-plugin</module>
-        <module>flowrecord-plugin</module>
     </modules>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,6 @@
         </profile>
     </profiles>
     <build>
-        <finalName>original-${project.artifactId}-${javaagent.version}</finalName>
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -202,8 +201,7 @@
                         </execution>
                     </executions>
                     <configuration>
-                        <finalName>${project.artifactId}-${javaagent.version}</finalName>
-                        <outputDirectory>${package.dir}</outputDirectory>
+                        <outputFile>${package.dir}/${project.artifactId}-${javaagent.version}.jar</outputFile>
                         <relocations>
                             <relocation>
                                 <pattern>com.alibaba</pattern>
@@ -274,9 +272,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.2.0</version>
-                <configuration>
-                    <outputDirectory>${project.build.directory}</outputDirectory>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
【issue号】无
【修改原因】
1.工程无法打包
2.插件无法运行
3.统一配置系统功能增强
4.连续执行package命令时，会多生成一些jar包
【修改内容】
1.移除多余的插件模块声明flowrecord-plugin
2.移除BootStrapImpl的调用
3.统一配置系统现在支持数组、List、Map和枚举
4.1.为第一个插件模块flowcontrol-plugin添加清理标记
4.2.shade打包现在使用outputFile标签，原为finalName+outputDirectory标签，避免未执行clean时直接执行package而导致的输出jar包异常
etc.移除多余的数据路由配置
【检查者】待定
【用例描述】暂无用例
【自测情况】本地功能测试通过
【影响范围】无兼容性问题，apm.config配置支持数组、List、Map和枚举，详见CommonLoadConfigStrategy中新增方法的注释