### PR TITLE
【bug修复】修复com.huawei.apm.premain.Transformer#enhanceConstructor中Builder的匹配错误的问题

### DIFF
--- a/lubanops-apm-javaagent-premain/src/main/java/com/huawei/apm/premain/Transformer.java
+++ b/lubanops-apm-javaagent-premain/src/main/java/com/huawei/apm/premain/Transformer.java
@@ -106,7 +106,7 @@ public class Transformer implements AgentBuilder.Transformer {
     private DynamicType.Builder<?> enhanceConstructor(ClassLoader classLoader,
             DynamicType.Builder<?> newBuilder,
             MultiInterMethodHolder methodHolder) {
-        return newBuilder.method(methodHolder.getMatcher())
+        return newBuilder.constructor(methodHolder.getMatcher())
                 .intercept(SuperMethodCall.INSTANCE.andThen(
                         MethodDelegation.withDefaultConfiguration().to(new ConstructorEnhancer(
                                 getInterceptors(methodHolder.getInterceptors(), classLoader, ConstructorInterceptor.class)))));


### PR DESCRIPTION
【issue号】#7

【修改原因】com.huawei.apm.premain.Transformer#enhanceConstructor中Builder的匹配错误，详见 issue #7 【其他信息】

【修改内容】将com.huawei.apm.premain.Transformer#enhanceConstructor方法中对net.bytebuddy.dynamic.DynamicType.Builder#method方法的调用修改为net.bytebuddy.dynamic.DynamicType.Builder#constructor

【检查者】@beetle-man @fuziye01 @3838438abcd

【用例描述】暂无用例

【自测情况】本地功能测试通过

【影响范围】详见 issue #7 【期望结果】